### PR TITLE
Fix typos in docs and sync example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 `Wahoo` is a Julia package designed for tracking the movement of marine
 animals using probabilistic state-space models. The inference is based
-on a discretion of space and does not use particles filters. This
- makes `Wahoo` working well also when the bathymetry is very rugged.
+on a discretization of space and does not use particle filters. This
+ makes `Wahoo` work well even when the bathymetry is very rugged.
 
 
 

--- a/docs/src/example.md
+++ b/docs/src/example.md
@@ -66,12 +66,14 @@ acoustic_pos = tuple.(moorings[:,2], moorings[:,3])
 function p_obs_acoustic(signals, t::Int, depth::Number, distance::Number)
     Wahoo.p_acoustic_sigmoid(signals[t], depth, distance)
 end
+
+acoustic_obs_models = [p_obs_acoustic, p_obs_acoustic]
 ```
 
 
 ### 4) Define parameters
 
-We define initial distribution of the fish location and configures the model parameters
+We define the initial distribution of the fish location and configure the model parameters
 such as time steps, movement capabilities of the fish, and spatial
 resolution of the bathymetry.
 
@@ -89,7 +91,7 @@ spatial_resolution = 200    # spatial resolution [m]
 
 ### 5) Run inference
 
-Finally, we run the model inference combine all observations and
+Finally, we run the model inference, combining all observations and
 assumptions.
 
 ```julia

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -44,7 +44,7 @@ Julia.
 ### HDF5
 
 [HDF5](https://en.wikipedia.org/wiki/Hierarchical_Data_Format) is a generic format for array like data that can be read from
-most languages. The function below export the result of `track` as
+most languages. The function below exports the result of `track` as
 hdf5. Note, you must install `HDF5.jl` additionally to `Wahoo`.
 
 ```Julia
@@ -92,8 +92,8 @@ end
 
 ##### Read HDF5 with Python
 
-The code below give an example who the data could be read with
-Python. Note, the order of the indices differ.
+The code below gives an example of how the data can be read with
+Python. Note, the order of the indices differs.
 
 ```python
 # /// script


### PR DESCRIPTION
## Summary
- fix README phrasing
- correct grammar in docs
- add missing acoustic observation model in example
- small wording improvements

## Testing
- `julia --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684042c114a8832b9aba80cebd05173d